### PR TITLE
商品出品時に、statusカラムが０になるよう修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,6 +21,7 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
+    @item.status = 0
     if @item.save!
       redirect_to controller: :items, action: :index
     else


### PR DESCRIPTION
statusカラムが０の状態を商品購入可能な状態にしているため、出品時はnilではなく、０が必ず入るよう修正しました