### PR TITLE
sold_fin

### DIFF
--- a/app/assets/stylesheets/items_screen_sold.scss
+++ b/app/assets/stylesheets/items_screen_sold.scss
@@ -1,0 +1,21 @@
+.item_screen__tag__off_sold{
+  width: 233px;
+  line-height: 72px;
+  font-weight: bold;
+  border-top: 2px solid #ececec;
+  background-color: #ececec;
+}
+
+.link_my_items{
+  text-decoration: none;
+  color: black;
+}
+
+.item_screen__tag__on_sold{
+  width: 233px;
+  line-height: 72px;
+  font-weight: bold;
+  color: black;
+  border-top: 2px solid #ea352d;
+  background-color: white;
+}

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -137,3 +137,13 @@
   color: #0099e8;
   font-size: 14px;
 }
+
+.new_regist{
+  color: white;
+  text-decoration: none;
+}
+
+.new_regist_google{
+  color: black;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/new.scss
+++ b/app/assets/stylesheets/new.scss
@@ -245,7 +245,6 @@ p.price{
   border-top: 1px solid #ccc;
 }
 
-.sell_profit__left{}
 .sell_btn_box {
   padding: 40px;
   border-top: 1px solid #eee;

--- a/app/assets/stylesheets/popular_category.scss
+++ b/app/assets/stylesheets/popular_category.scss
@@ -194,9 +194,14 @@
   color: white;
   font-size: 18px;
   z-index: 10;
-  margin-top: 80px;
+  margin-top: 60px;
   background-color: red;
   height: 22px;
   width: 100%;
   text-align: center;
+  -webkit-transform: rotate(-20deg);
+     -moz-transform: rotate(-20deg);
+      -ms-transform: rotate(-20deg);
+       -o-transform: rotate(-20deg);
+          transform: rotate(-20deg);
 }

--- a/app/assets/stylesheets/selling.scss
+++ b/app/assets/stylesheets/selling.scss
@@ -447,11 +447,30 @@ li.item_name  {
   color: white;
   background-color: red;
   width: 300px;
-  margin-top: 140px;
+  margin-top: 120px;
   text-align: center;
+  -webkit-transform: rotate(-20deg);
+  -moz-transform: rotate(-20deg);
+   -ms-transform: rotate(-20deg);
+    -o-transform: rotate(-20deg);
+       transform: rotate(-20deg);
 }
 
 .photos_box{
   position: absolute;
   top: 0px;
+}
+
+.edit_mypage__content_sold{
+  margin-top: 100px;
+}
+
+.btn-default{
+  text-decoration: none;
+  color: black;
+}
+
+.btn-default2{
+  text-decoration: none;
+  color: white;
 }

--- a/app/assets/stylesheets/sign_up.scss
+++ b/app/assets/stylesheets/sign_up.scss
@@ -56,9 +56,18 @@
   background-color: #fff;
 }
 
+.fb_registration{
+  color: white;
+  text-decoration: none;
+}
+
 .fab.fa-google{
-  color: black;
   font-size: 20px;
+}
+
+.google_regostration{
+  color: black;
+  text-decoration: none;
 }
 
 .fa-envelope.fa-facebook-square{
@@ -71,7 +80,6 @@
   text-align: center;
   border-bottom: 2px solid #f5f5f5;
 }
-
 
 .btn-default{
   display: block;

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -22,13 +22,21 @@ class MypagesController < ApplicationController
 
   def items_screen
     @items = Item.order("created_at DESC")
+  end
 
+  def items_screen_sold
+    @items = Item.order("created_at DESC")
   end
 
 
   def selling
     @item = Item.find(params[:id])
     @images = @item.images
+  end
+
+  def selling_sold
+    @item = Item.find(params[:id])
+    @images = @item.images  
   end
 
   def personal_page

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -78,7 +78,7 @@
         - if @items.status == "1"
           = link_to "取引が終了したアイテムです", root_path, method: "GET" ,class:"btn-default",style: "background-color: lightgray"
         - else 
-          = link_to "購入する", item_cards_confirmation_path(@items.id)
+          = link_to "購入する", item_cards_confirmation_path(@items.id) ,class: "btn-default2"
       .shipping_note_message
         -if @items.delivery_way_id ==10
           %p この商品はゆうゆうフリマ便を利用しているため、アプリからのみ購入できます。

--- a/app/views/mypages/_side_content.html.haml
+++ b/app/views/mypages/_side_content.html.haml
@@ -32,7 +32,7 @@
           .fas.fa-chevron-right
       %li
         .mypage_side_content__nav_list_item 
-          出品した商品 - 売却済み
+          = link_to "出品した商品 - 売却済み" ,items_screen_sold_mypages_path
           .icon.fas.fa-chevron-right
       %li
         .mypage_side_content__nav_list_item 

--- a/app/views/mypages/items_screen_sold.html.haml
+++ b/app/views/mypages/items_screen_sold.html.haml
@@ -10,17 +10,17 @@
         .item_screen__body_header
           出品した商品
         .item_screen__tag
-          .item_screen__tag__on
-            出品中
+          .item_screen__tag__off_sold
+            = link_to "出品中" ,items_screen_mypages_path, class: "link_my_items"
           .item_screen__tag__off
             取引中
-          .item_screen__tag__off
-            = link_to "売却済み", items_screen_sold_mypages_path, class: "link_my_items"
+          .item_screen__tag__on_sold
+            売却済み
 
         .item_screen__box
           - @items.each do |item|
-            -if item.status == "0" && item.seller_id == current_user.id
-              = link_to selling_mypage_path(item.id), class: "selling_my_item" do
+            -if item.status == "1" && item.seller_id == current_user.id
+              = link_to selling_sold_mypage_path(item.id), class: "selling_my_item" do
                 .item_screen__box__items
                   = item.name
                   .item_screen__box__items__img
@@ -35,24 +35,8 @@
                     .item_screen__box__items__icons__comment
                       22
                     .item_screen__box__items__icons__selling
-                      出品中
+                      売却済み
 
   %section
     = render "items/sheard/bottom_image"
     = render "items/sheard/footer"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/app/views/mypages/selling_sold.html.haml
+++ b/app/views/mypages/selling_sold.html.haml
@@ -1,0 +1,106 @@
+-# config/breadcrumbs.rbに定義したmypageを呼び出し
+.mypage
+  = render "items/sheard/header"
+
+  -# 下記を記述した箇所にパンくずリストが表示される。
+  - breadcrumb :selling
+  = render "layouts/breadcrumbs"
+
+  .mypage_html
+    .mypage_index
+      = render "side_content"
+      .item__details
+        %h2.item__details__name
+          = @item.name
+        .item__details__main_content
+          .item__details__main_content_boxes
+            .main_photo
+              %p.sold_2 SOLD
+              .photos_box
+                .photos
+                  = image_tag "#{@item.images[0].image_url}", class: "photos"
+                .small_photos
+                  - @images.each do |image|
+                    = image_tag image.image_url.to_s, class: "small_photo"
+
+
+            %table.item_detail_table
+              %tbody
+                %tr
+                  %th 出品者
+                  %td
+                    .seller_name chanken
+                    .user_rating
+                      .item_user_ratings
+                      %i.fas.fa-laugh
+                      %span 131
+                      .item_user_ratings
+                      %i.fas.fa-meh
+                      %span 3
+                      .item_user_ratings
+                      %i.fas.fa-frown
+                      %span 1
+                %tr
+                  %th カテゴリー
+                  %td
+                    .item_category
+                      .item_category_top
+                      %span 
+                        = @item.category_id
+
+                %tr
+                  %th ブランド
+                  %td 
+                    = @item.brand_id
+                %tr
+                  %th 商品サイズ
+                  %td 
+                    = @item.size_id
+                %tr
+                  %th 商品の状態
+                  %td 
+                    = @item.condition_id
+                %tr
+                  %th 配送料の負担
+                  %td 
+                    = @item.delivery_charge_id
+                %tr
+                  %th 配送の方法
+                  %td 
+                    = @item.delivery_way_id
+                %tr
+                  %th 発送元地域
+                  %td 
+                    = @item.prefecture_id
+                %tr
+                  %th 発送日の目安
+                  %td 
+                    = @item.delivery_days_id
+          .item_price_box
+            %span.item_price
+              = "¥#{@item.price}"
+            %span.item_tax (税込)
+            %span.item_shipping_fee 送料込み
+          .item_buy_btn
+            = link_to "取引が終了したアイテムです", root_path, method: "GET" ,class:"btn-default",style: "background-color: lightgray"
+            .item_button_container
+              .item_button
+                .item_button__left
+                  .fas.fa-heart いいね
+                .item_button__right
+                  .fas.fa-flag  不適切な商品の報告
+              .item_text
+                .fas.fa-unlock-alt  あんしん・あんぜんへの取り組み
+
+   
+
+          .edit_mypage__content_sold
+            .edit_mypage__content__caution
+              相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+            .edit_mypage__content__fill
+            .edit_mypage__content__comment
+              コメントする
+
+  %section
+    = render "items/sheard/bottom_image"
+    = render "items/sheard/footer"

--- a/app/views/signup/index.html.haml
+++ b/app/views/signup/index.html.haml
@@ -11,10 +11,10 @@
             メールアドレスで登録する
           %button#facebook-login.btn-default.btn_facebook
             %i.fab.fa-facebook-square
-            = link_to 'Facebookで登録', user_facebook_omniauth_authorize_path, method: :post
+            = link_to 'Facebookで登録', user_facebook_omniauth_authorize_path, method: :post, class: "fb_registration"
           %button#google-login.btn-default.btn_googl
             %i.fab.fa-google
-            = link_to 'Googleで登録', user_google_oauth2_omniauth_authorize_path, method: :post
+            = link_to 'Googleで登録', user_google_oauth2_omniauth_authorize_path, method: :post, class: "google_regostration"
   
   .user_sign_footer
     = render "/items/sheard/icon_footer"

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -8,14 +8,14 @@
             .new_user
               %p.new_user_acount アカウントをお持ちでない方はこちら
               .new_user_bottom 
-                = link_to "新規会員登録", signup_index_path
+                = link_to "新規会員登録", signup_index_path, class: "new_regist"
             .login_form
               %button#facebook_login.btn-default1.btn_facebook
                 %i.fab.fa-facebook-square
-                = link_to 'Facebookでログイン', user_facebook_omniauth_authorize_path, method: :post
+                = link_to 'Facebookでログイン', user_facebook_omniauth_authorize_path, method: :post, class: "new_regist"
               %button#google-login.btn-default1.btn_googl
                 %i.fab.fa-google
-                = link_to 'Googleでログイン', user_google_oauth2_omniauth_authorize_path, method: :post
+                = link_to 'Googleでログイン', user_google_oauth2_omniauth_authorize_path, method: :post, class: "new_regist_google"
             .form_content
               .bottom_contents
                 = f.email_field :email, autocomplete: "email", class:'login_mail',placeholder:'メールアドレス'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,10 +53,12 @@ Rails.application.routes.draw do
   resources :mypages do
     member do   # idありの自作アクション
       get :selling
+      get :selling_sold
     end
 
     collection do  #idなしのあ自作アクション」」
       get :items_screen
+      get :items_screen_sold
       get :logout
     end
   end


### PR DESCRIPTION
What
マイページの売却済みボタンから売却済みページへリンクし、カレントユーザーが売却した商品の一覧が表示されるようにした。
Why
ユーザーが過去に売却した商品や、出品中の商品を確認できることで商品の管理がしやすくなる為。