### PR TITLE
マイページでニックネーム表示するよう変更。ユーザー出品数で全ての出品数表示されていたのを変更

### DIFF
--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -57,6 +57,9 @@ li{
   float: right;
   padding-top: 40px;
   width: 700px;
+  &__user_name{
+    font-size:25px;
+  }
   &__user_icon{
     background-image: url(/icon/mypage_sample.jpeg);
     height: 155px;

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -42,6 +42,7 @@ class MypagesController < ApplicationController
   def personal_page
     # @items = Item.where(seller_id: current_user.id)
     @items = Item.all
+    @selling_items = @items.where(seller_id: current_user.id)
   end
 
   def destroy

--- a/app/views/mypages/_main_content.html.haml
+++ b/app/views/mypages/_main_content.html.haml
@@ -2,13 +2,15 @@
 .mypage_content
   %section.mypage_content__user_icon
     %figure= image_tag '/icon/mypage_icon.jpeg' ,width: 60,height: 60
+    .mypage_content__user_name
+      = "#{current_user.nickname}"
     %h2 
     .mypage_content__number
       .mypage_content__evaluation
         評価
         %span.bold 0
       .mypage_content__sell-product
-        = "出品数 #{items.count}"
+        = "出品数 #{selling_items.count}"
   -# お知らせタブ
   %ul.mypage_content__tabs
     %li.info

--- a/app/views/mypages/personal_page.html.haml
+++ b/app/views/mypages/personal_page.html.haml
@@ -9,7 +9,7 @@
   .mypage_html
     .mypage_index
       = render "side_content"
-      = render "main_content", items: @items
+      = render "main_content", items: @items,selling_items: @selling_items
 
   %section
     = render "items/sheard/bottom_image"


### PR DESCRIPTION
# What
ユーザー名がマイページアクセスした時表示されるよう変更
マイページの出品数がログイン中のユーザーの出品した数ではなく、出品された全ての商品の数になっていたのを修正
#  Why
購入用のアカウントと出品用のアカウントを分けるに当たって、今ログインしているのが、どちらのユーザーかわからないと利便性が下がるため。
出品数など細かな点の修正を行い、完成度を高めるため
